### PR TITLE
fix(analytics) Add type and source type info to page events

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,5 +1,5 @@
 import { Tracker } from 'san-webkit/lib/analytics'
-import { trackAuthFinish, trackLoginFinish } from 'san-webkit/lib/analytics/events/general'
+import { LoginType, PageType, trackAuthFinish, trackLoginFinish } from 'san-webkit/lib/analytics/events/general'
 import { trackSignupFinish } from 'san-webkit/lib/analytics/events/onboarding'
 
 export function trackSignupLogin(isFirstLogin: boolean, method: LoginType) {
@@ -16,4 +16,16 @@ export function trackSignupLogin(isFirstLogin: boolean, method: LoginType) {
   } else {
     trackLoginFinish(method)
   }
+}
+
+export function getPageType(pathname: string) {
+  if (pathname.startsWith('/query')) return 'query'
+
+  if (pathname.startsWith('/dashboard')) return 'dashboard'
+
+  if (pathname.startsWith('/explorer')) return 'queries_explorer'
+
+  if (pathname.startsWith('/login')) return PageType.Login
+
+  if (pathname.startsWith('/sign-up')) return PageType.SignUp
 }

--- a/src/routes/Tracking.svelte
+++ b/src/routes/Tracking.svelte
@@ -8,7 +8,7 @@
   import { trackPageView } from 'san-webkit/lib/analytics/events/general'
   import { parseAuthSearchParams } from 'san-webkit/lib/utils/auth'
   import { page } from '$app/stores'
-  import { trackSignupLogin } from '$lib/utils/analytics'
+  import { getPageType, trackSignupLogin } from '$lib/utils/analytics'
 
   const { currentUser$ } = getCurrentUser$Ctx()
 
@@ -41,9 +41,11 @@
     if (source !== path) {
       trackPageView({
         url: path,
+        type: getPageType(path),
         searchParams,
 
         sourceUrl: source,
+        sourceType: getPageType(source),
         sourceSearchParams,
       } as any)
     }


### PR DESCRIPTION
## Summary 
Add type and source type info to page events

## Notion page
https://www.notion.so/santiment/Queries-page-view-types-228f868fa4ef4f80b35f30e2103da44d?pvs=4